### PR TITLE
Fix incorrect usage for arg bool

### DIFF
--- a/evaporate/run.sh
+++ b/evaporate/run.sh
@@ -3,21 +3,20 @@ keys="PLACEHOLDER" # INSERT YOUR API KEY(S) HERE
 # evaporate code closed ie
 python run_profiler.py \
     --data_lake fda_510ks \
-    --do_end_to_end False \
     --num_attr_to_cascade 50 \
     --num_top_k_scripts 10 \
     --train_size 10 \
     --combiner_mode ws \
-    --use_dynamic_backoff True \
+    --use_dynamic_backoff \
     --KEYS ${keys}
 
 # evaporate code open ie
 python run_profiler.py \
     --data_lake fda_510ks \
-    --do_end_to_end True \
+    --do_end_to_end \
     --num_attr_to_cascade 1 \
     --num_top_k_scripts 10 \
     --train_size 10 \
     --combiner_mode ws \
-    --use_dynamic_backoff True \
+    --use_dynamic_backoff \
     --KEYS ${keys}

--- a/evaporate/run_profiler.py
+++ b/evaporate/run_profiler.py
@@ -390,8 +390,8 @@ def get_experiment_args():
 
     parser.add_argument(
         "--do_end_to_end", 
-        type=bool,
-        default=True,
+        dest='do_end_to_end',
+        action='store_true',
         help="True for OpenIE, False for ClosedIE"
     )
 
@@ -426,8 +426,8 @@ def get_experiment_args():
 
     parser.add_argument(
         "--use_dynamic_backoff",
-        type=bool,
-        default=True,
+        dest='use_dynamic_backoff',
+        action='store_true',
         help="Whether to generate functions or do Evaporate-Direct",
     )
 


### PR DESCRIPTION
Seems the usage with `argparse` 's bool arguments is not correct, make the `do_end_to_end` always `Ture`.
fix `use_dynamic_backoff` either, same problem
